### PR TITLE
Add sub2api admin API key upload mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,12 @@ PROXY=socks5://127.0.0.1:7890
 
 在页面底部的「sub2api 上传配置」中填入：
 - **sub2api 地址** — 你的 sub2api 实例地址（如 `http://127.0.0.1:8080`）
-- **管理员邮箱** — sub2api 管理员账号
-- **管理员密码** — sub2api 管理员密码
+- **认证方式** — 可选择管理员邮箱/密码，或 Admin API Key
+- **管理员邮箱 / 管理员密码** — 使用 sub2api 管理员账号登录后创建账号（原有方式）
+- **Admin API Key** — 使用 sub2api 后台生成的管理员 API Key，通过 `x-api-key` 请求头创建账号
 - **提取后自动上传** — 勾选后每次提取完成自动上传到 sub2api
+
+使用 Admin API Key 时，需要先在 sub2api 后台「设置」中生成管理员 API Key。上传时工具会调用 `POST /api/v1/admin/accounts`，用提取到的 `refresh_token` 自动创建 OpenAI OAuth 账号，并在页面日志中回显创建出的账号 ID、状态和认证方式。
 
 ## 输出格式
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ PROXY=socks5://127.0.0.1:7890
 
 使用 Admin API Key 时，需要先在 sub2api 后台「设置」中生成管理员 API Key。上传时工具会调用 `POST /api/v1/admin/accounts`，用提取到的 `refresh_token` 自动创建 OpenAI OAuth 账号，并在页面日志中回显创建出的账号 ID、状态和认证方式。
 
+配置会保存到本地 `config/sub2api.json`（该文件不会提交）。可参考 `config/sub2api.example.json`：
+
+```json
+{
+  "base_url": "http://127.0.0.1:8080",
+  "auth_mode": "admin_api_key",
+  "admin_email": "",
+  "admin_password": "",
+  "admin_api_key": "your-admin-api-key",
+  "enabled": false
+}
+```
+
 ## 输出格式
 
 凭证文件命名格式：`codex-{邮箱}-plus.json`

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ PROXY=socks5://127.0.0.1:7890
 
 使用 Admin API Key 时，需要先在 sub2api 后台「设置」中生成管理员 API Key。上传时工具会调用 `POST /api/v1/admin/accounts`，用提取到的 `refresh_token` 自动创建 OpenAI OAuth 账号，并在页面日志中回显创建出的账号 ID、状态和认证方式。
 
-如果已经有 `refresh_token`，也可以不执行提取流程，直接在「直接上传 refresh token」区域粘贴 token 并提交。邮箱和账号名称为可选字段，仅用于创建账号时命名和页面回显；`refresh_token` 不会保存到本地配置文件。
+如果已经有 `refresh_token`，也可以不执行提取流程，直接在「直接上传 refresh token」区域粘贴 token 并提交。邮箱和账号名称为可选字段，仅用于创建账号时命名和页面回显；如果两者都为空，会自动生成 `manual-rt-YYYYMMDD-HHMMSS-xxxxxx` 格式的账号名，避免重复。`refresh_token` 不会保存到本地配置文件。
 
 配置会保存到本地 `config/sub2api.json`（该文件不会提交）。可参考 `config/sub2api.example.json`：
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ PROXY=socks5://127.0.0.1:7890
 
 使用 Admin API Key 时，需要先在 sub2api 后台「设置」中生成管理员 API Key。上传时工具会调用 `POST /api/v1/admin/accounts`，用提取到的 `refresh_token` 自动创建 OpenAI OAuth 账号，并在页面日志中回显创建出的账号 ID、状态和认证方式。
 
+如果已经有 `refresh_token`，也可以不执行提取流程，直接在「直接上传 refresh token」区域粘贴 token 并提交。邮箱和账号名称为可选字段，仅用于创建账号时命名和页面回显；`refresh_token` 不会保存到本地配置文件。
+
 配置会保存到本地 `config/sub2api.json`（该文件不会提交）。可参考 `config/sub2api.example.json`：
 
 ```json

--- a/config/sub2api.example.json
+++ b/config/sub2api.example.json
@@ -1,0 +1,8 @@
+{
+  "base_url": "http://127.0.0.1:8080",
+  "auth_mode": "admin_api_key",
+  "admin_email": "",
+  "admin_password": "",
+  "admin_api_key": "your-admin-api-key",
+  "enabled": false
+}

--- a/lib/sub2apiService.js
+++ b/lib/sub2apiService.js
@@ -52,7 +52,7 @@ function doRequest(url, opts, body) {
   });
 }
 
-async function uploadToSub2Api(sub2ApiConfig, tokenData) {
+async function uploadToSub2Api(sub2ApiConfig, tokenData, options = {}) {
   const { URL } = require('url');
   const cfg = normalizeSub2ApiConfig(sub2ApiConfig);
 
@@ -89,7 +89,7 @@ async function uploadToSub2Api(sub2ApiConfig, tokenData) {
   const accountBody = JSON.stringify({
     platform: 'openai',
     type: 'oauth',
-    name: tokenData.email || 'extracted',
+    name: options.name || tokenData.email || 'extracted',
     credentials: {
       refresh_token: refreshToken,
       client_id: OPENAI_CODEX_CLIENT_ID,

--- a/lib/sub2apiService.js
+++ b/lib/sub2apiService.js
@@ -1,0 +1,136 @@
+const http = require('http');
+const https = require('https');
+
+const OPENAI_CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+
+function normalizeSub2ApiConfig(raw) {
+  const cfg = raw && typeof raw === 'object' ? raw : {};
+  const authMode = cfg.auth_mode === 'admin_api_key' ? 'admin_api_key' : 'email_password';
+  return {
+    base_url: typeof cfg.base_url === 'string' ? cfg.base_url.replace(/\/+$/, '') : '',
+    auth_mode: authMode,
+    admin_email: typeof cfg.admin_email === 'string' ? cfg.admin_email : '',
+    admin_password: typeof cfg.admin_password === 'string' ? cfg.admin_password : '',
+    admin_api_key: typeof cfg.admin_api_key === 'string' ? cfg.admin_api_key : '',
+    enabled: !!cfg.enabled,
+  };
+}
+
+function isSub2ApiConfigReady(cfg) {
+  const normalized = normalizeSub2ApiConfig(cfg);
+  if (!normalized.base_url) return false;
+  if (normalized.auth_mode === 'admin_api_key') return !!normalized.admin_api_key;
+  return !!normalized.admin_email && !!normalized.admin_password;
+}
+
+function missingSub2ApiConfigMessage(cfg) {
+  const normalized = normalizeSub2ApiConfig(cfg);
+  if (!normalized.base_url) return '请先配置 sub2api 地址';
+  if (normalized.auth_mode === 'admin_api_key') return '请先配置 sub2api Admin API Key';
+  return '请先配置 sub2api 地址和管理员账号';
+}
+
+function parseJsonBody(body, fallbackMessage) {
+  try {
+    return body ? JSON.parse(body) : null;
+  } catch {
+    throw new Error(fallbackMessage);
+  }
+}
+
+function doRequest(url, opts, body) {
+  return new Promise((resolve, reject) => {
+    const transport = url.protocol === 'https:' ? https : http;
+    const req = transport.request(url, opts, (resp) => {
+      let data = '';
+      resp.on('data', chunk => data += chunk);
+      resp.on('end', () => resolve({ statusCode: resp.statusCode, body: data }));
+    });
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+async function uploadToSub2Api(sub2ApiConfig, tokenData) {
+  const { URL } = require('url');
+  const cfg = normalizeSub2ApiConfig(sub2ApiConfig);
+
+  let adminHeaders;
+  let authMethod;
+
+  if (cfg.auth_mode === 'admin_api_key') {
+    adminHeaders = { 'x-api-key': cfg.admin_api_key };
+    authMethod = 'admin_api_key';
+  } else {
+    const loginUrl = new URL('/api/v1/auth/login', cfg.base_url);
+    const loginBody = JSON.stringify({ email: cfg.admin_email, password: cfg.admin_password });
+
+    const loginResult = await doRequest(loginUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(loginBody) },
+    }, loginBody);
+
+    if (loginResult.statusCode !== 200) {
+      throw new Error(`sub2api 登录失败 ${loginResult.statusCode}: ${loginResult.body}`);
+    }
+
+    const loginData = parseJsonBody(loginResult.body, 'sub2api 登录返回非 JSON 响应');
+    const jwt = loginData?.data?.access_token;
+    if (!jwt) throw new Error('sub2api 登录返回无 token');
+    adminHeaders = { 'Authorization': `Bearer ${jwt}` };
+    authMethod = 'email_password';
+  }
+
+  const accountUrl = new URL('/api/v1/admin/accounts', cfg.base_url);
+  const refreshToken = tokenData.refresh_token;
+  if (!refreshToken) throw new Error('Token 文件缺少 refresh_token');
+
+  const accountBody = JSON.stringify({
+    platform: 'openai',
+    type: 'oauth',
+    name: tokenData.email || 'extracted',
+    credentials: {
+      refresh_token: refreshToken,
+      client_id: OPENAI_CODEX_CLIENT_ID,
+    },
+  });
+
+  const createResult = await doRequest(accountUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...adminHeaders,
+      'Content-Length': Buffer.byteLength(accountBody),
+    },
+  }, accountBody);
+
+  if (createResult.statusCode >= 400) {
+    throw new Error(`sub2api 创建账号失败 ${createResult.statusCode}: ${createResult.body}`);
+  }
+
+  const responseBody = parseJsonBody(createResult.body, 'sub2api 创建账号返回非 JSON 响应');
+  const account = responseBody?.data || responseBody;
+  return {
+    status: createResult.statusCode,
+    body: createResult.body,
+    auth_method: authMethod,
+    account: {
+      id: account?.id ?? null,
+      name: account?.name ?? null,
+      platform: account?.platform ?? null,
+      type: account?.type ?? null,
+      status: account?.status ?? null,
+      schedulable: account?.schedulable ?? null,
+      email: account?.extra?.email || tokenData.email || null,
+    },
+  };
+}
+
+module.exports = {
+  OPENAI_CODEX_CLIENT_ID,
+  normalizeSub2ApiConfig,
+  isSub2ApiConfigReady,
+  missingSub2ApiConfigMessage,
+  uploadToSub2Api,
+};

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "express": "^4.21.0",

--- a/public/app.js
+++ b/public/app.js
@@ -616,6 +616,48 @@
     }
   });
 
+  $('#sub2api-refresh-token-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const refreshToken = $('#sub2api-rt').value.trim();
+    const email = $('#sub2api-manual-email').value.trim();
+    const name = $('#sub2api-manual-name').value.trim();
+    if (!refreshToken) {
+      showSub2ApiStatus('refresh_token 必填', false);
+      return;
+    }
+
+    const btn = $('#sub2api-upload-rt-btn');
+    btn.disabled = true;
+    btn.textContent = '上传中...';
+    const headers = { 'Content-Type': 'application/json' };
+    if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+    try {
+      const resp = await fetch('/api/upload-refresh-token-to-sub2api', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          refresh_token: refreshToken,
+          email,
+          name,
+        })
+      });
+      const data = await resp.json();
+      if (resp.ok) {
+        const summary = `refresh token 上传成功${formatSub2ApiUploadResult(data)}`;
+        showSub2ApiStatus(summary, true);
+        appendLog('sub2api', summary);
+        $('#sub2api-rt').value = '';
+      } else {
+        showSub2ApiStatus('上传失败: ' + (data.error || '未知错误'), false);
+      }
+    } catch (err) {
+      showSub2ApiStatus('网络错误: ' + err.message, false);
+    } finally {
+      btn.disabled = false;
+      btn.textContent = '上传 refresh token';
+    }
+  });
+
   // sub2api 一键上传全部
   $('#sub2api-upload-all-btn').addEventListener('click', async () => {
     const btn = $('#sub2api-upload-all-btn');

--- a/public/app.js
+++ b/public/app.js
@@ -183,6 +183,17 @@
     return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   }
 
+  function formatSub2ApiUploadResult(data) {
+    const account = data?.account;
+    if (!account) return '';
+    const parts = [];
+    if (account.id !== null && account.id !== undefined) parts.push(`ID ${account.id}`);
+    if (account.name) parts.push(account.name);
+    if (account.status) parts.push(`状态 ${account.status}`);
+    if (data.auth_method) parts.push(`认证 ${data.auth_method === 'admin_api_key' ? 'x-api-key' : '邮箱/密码'}`);
+    return parts.length ? ` (${parts.join(' / ')})` : '';
+  }
+
   function showResult(result, filename) {
     resultSection.hidden = false;
     currentFilename = filename;
@@ -262,6 +273,7 @@
       const data = await resp.json();
       if (resp.ok) {
         btn.textContent = '已上传';
+        appendLog('sub2api', `创建账号成功${formatSub2ApiUploadResult(data)}`);
         setTimeout(() => btn.textContent = '上传到 sub2api', 2000);
       } else {
         alert('上传失败: ' + data.error);
@@ -393,6 +405,7 @@
           const data = await resp.json();
           if (resp.ok) {
             btn.textContent = '已上传';
+            appendLog('sub2api', `${filename} 创建账号成功${formatSub2ApiUploadResult(data)}`);
           } else {
             btn.textContent = '上传sub2api';
             alert('上传失败: ' + data.error);
@@ -540,6 +553,28 @@
   }
 
   // ── sub2api 配置 ──
+  function getSub2ApiAuthMode() {
+    return document.querySelector('input[name="sub2api-auth-mode"]:checked')?.value || 'email_password';
+  }
+
+  function setSub2ApiAuthMode(mode) {
+    const normalized = mode === 'admin_api_key' ? 'admin_api_key' : 'email_password';
+    const radio = document.querySelector(`input[name="sub2api-auth-mode"][value="${normalized}"]`);
+    if (radio) radio.checked = true;
+    updateSub2ApiAuthFields();
+  }
+
+  function updateSub2ApiAuthFields() {
+    const useAdminApiKey = getSub2ApiAuthMode() === 'admin_api_key';
+    $('#sub2api-email').closest('.form-group').hidden = useAdminApiKey;
+    $('#sub2api-pwd').closest('.form-group').hidden = useAdminApiKey;
+    $('#sub2api-key-group').hidden = !useAdminApiKey;
+  }
+
+  document.querySelectorAll('input[name="sub2api-auth-mode"]').forEach(input => {
+    input.addEventListener('change', updateSub2ApiAuthFields);
+  });
+
   async function loadSub2ApiConfig() {
     try {
       const headers = {};
@@ -548,8 +583,10 @@
       if (resp.ok) {
         const cfg = await resp.json();
         $('#sub2api-url').value = cfg.base_url || '';
+        setSub2ApiAuthMode(cfg.auth_mode || 'email_password');
         $('#sub2api-email').value = cfg.admin_email || '';
         $('#sub2api-pwd').value = cfg.admin_password || '';
+        $('#sub2api-admin-key').value = cfg.admin_api_key || '';
         $('#sub2api-auto').checked = !!cfg.enabled;
       }
     } catch {}
@@ -565,8 +602,10 @@
         headers,
         body: JSON.stringify({
           base_url: $('#sub2api-url').value.trim(),
+          auth_mode: getSub2ApiAuthMode(),
           admin_email: $('#sub2api-email').value.trim(),
           admin_password: $('#sub2api-pwd').value,
+          admin_api_key: $('#sub2api-admin-key').value.trim(),
           enabled: $('#sub2api-auto').checked
         })
       });
@@ -588,7 +627,9 @@
       const resp = await fetch('/api/upload-all-to-sub2api', { method: 'POST', headers });
       const data = await resp.json();
       if (resp.ok) {
-        showSub2ApiStatus(`上传完成: 成功 ${data.success} 个, 失败 ${data.failed} 个`, data.failed === 0);
+        const authMethods = [...new Set((data.details || []).filter(d => d.auth_method).map(d => d.auth_method === 'admin_api_key' ? 'x-api-key' : '邮箱/密码'))];
+        const suffix = authMethods.length ? `，认证: ${authMethods.join(', ')}` : '';
+        showSub2ApiStatus(`上传完成: 成功 ${data.success} 个, 失败 ${data.failed} 个${suffix}`, data.failed === 0);
       } else {
         showSub2ApiStatus('上传失败: ' + data.error, false);
       }
@@ -607,6 +648,8 @@
     el.className = 'cpa-status ' + (ok ? 'cpa-ok' : 'cpa-err');
     setTimeout(() => el.hidden = true, 5000);
   }
+
+  updateSub2ApiAuthFields();
 
   checkAuth();
   connectWS();

--- a/public/index.html
+++ b/public/index.html
@@ -161,7 +161,7 @@
             <input type="email" id="sub2api-manual-email" placeholder="user@example.com">
           </div>
           <div class="form-group">
-            <label for="sub2api-manual-name">账号名称 <span class="optional">可选，默认使用邮箱或 extracted</span></label>
+            <label for="sub2api-manual-name">账号名称 <span class="optional">可选，默认使用邮箱或随机名称</span></label>
             <input type="text" id="sub2api-manual-name" placeholder="OpenAI account name">
           </div>
           <div class="cpa-actions">

--- a/public/index.html
+++ b/public/index.html
@@ -149,6 +149,26 @@
           <button type="button" id="sub2api-upload-all-btn" class="btn-secondary btn-sub2api">一键上传全部</button>
         </div>
       </form>
+      <div class="manual-token-panel">
+        <h3>直接上传 refresh token</h3>
+        <form id="sub2api-refresh-token-form">
+          <div class="form-group">
+            <label for="sub2api-rt">Refresh Token <span class="required">*</span></label>
+            <textarea id="sub2api-rt" rows="4" placeholder="rt_..." spellcheck="false"></textarea>
+          </div>
+          <div class="form-group">
+            <label for="sub2api-manual-email">邮箱 <span class="optional">可选，用于回显</span></label>
+            <input type="email" id="sub2api-manual-email" placeholder="user@example.com">
+          </div>
+          <div class="form-group">
+            <label for="sub2api-manual-name">账号名称 <span class="optional">可选，默认使用邮箱或 extracted</span></label>
+            <input type="text" id="sub2api-manual-name" placeholder="OpenAI account name">
+          </div>
+          <div class="cpa-actions">
+            <button type="submit" id="sub2api-upload-rt-btn" class="btn-primary btn-sub2api">上传 refresh token</button>
+          </div>
+        </form>
+      </div>
       <div id="sub2api-status" class="cpa-status" hidden></div>
     </section>
   </div>

--- a/public/index.html
+++ b/public/index.html
@@ -114,12 +114,29 @@
           <input type="url" id="sub2api-url" placeholder="http://127.0.0.1:8080">
         </div>
         <div class="form-group">
+          <label>认证方式</label>
+          <div class="sub2api-auth-options">
+            <label class="inline-option">
+              <input type="radio" name="sub2api-auth-mode" value="email_password" checked>
+              <span>管理员邮箱/密码</span>
+            </label>
+            <label class="inline-option">
+              <input type="radio" name="sub2api-auth-mode" value="admin_api_key">
+              <span>Admin API Key (x-api-key)</span>
+            </label>
+          </div>
+        </div>
+        <div class="form-group">
           <label for="sub2api-email">管理员邮箱</label>
           <input type="email" id="sub2api-email" placeholder="admin@sub2api.local">
         </div>
         <div class="form-group">
           <label for="sub2api-pwd">管理员密码</label>
           <input type="password" id="sub2api-pwd" placeholder="admin password">
+        </div>
+        <div class="form-group" id="sub2api-key-group" hidden>
+          <label for="sub2api-admin-key">Admin API Key <span class="optional">请求头 x-api-key</span></label>
+          <input type="password" id="sub2api-admin-key" placeholder="s2a_...">
         </div>
         <div class="form-group cpa-toggle-row">
           <label class="toggle-label">

--- a/public/style.css
+++ b/public/style.css
@@ -88,6 +88,29 @@ header h1 {
 .required { color: var(--danger); }
 .optional { color: var(--text-dim); font-weight: normal; font-size: 0.8rem; }
 
+.sub2api-auth-options {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.inline-option {
+  display: inline-flex !important;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.inline-option input {
+  width: auto;
+  margin: 0;
+}
+
 .btn-primary, .btn-secondary, .btn-danger {
   display: inline-block;
   padding: 10px 20px;

--- a/public/style.css
+++ b/public/style.css
@@ -81,7 +81,23 @@ header h1 {
   transition: border-color 0.2s;
 }
 
-.form-group input:focus {
+.form-group textarea {
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 0.95rem;
+  outline: none;
+  resize: vertical;
+  min-height: 96px;
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+  transition: border-color 0.2s;
+}
+
+.form-group input:focus,
+.form-group textarea:focus {
   border-color: var(--accent);
 }
 
@@ -109,6 +125,18 @@ header h1 {
 .inline-option input {
   width: auto;
   margin: 0;
+}
+
+.manual-token-panel {
+  margin-top: 18px;
+  padding-top: 18px;
+  border-top: 1px solid var(--border);
+}
+
+.manual-token-panel h3 {
+  font-size: 0.95rem;
+  margin-bottom: 12px;
+  color: var(--text);
 }
 
 .btn-primary, .btn-secondary, .btn-danger {

--- a/server.js
+++ b/server.js
@@ -366,6 +366,31 @@ app.post('/api/upload-to-sub2api', async (req, res) => {
   }
 });
 
+// ── 直接提交 refresh_token 到 sub2api ──
+app.post('/api/upload-refresh-token-to-sub2api', async (req, res) => {
+  const refreshToken = typeof req.body.refresh_token === 'string' ? req.body.refresh_token.trim() : '';
+  const email = typeof req.body.email === 'string' ? req.body.email.trim() : '';
+  const name = typeof req.body.name === 'string' ? req.body.name.trim() : '';
+  if (!refreshToken) return res.status(400).json({ error: 'refresh_token 必填' });
+
+  const cfg = loadSub2ApiConfig();
+  if (!isSub2ApiConfigReady(cfg)) {
+    return res.status(400).json({ error: missingSub2ApiConfigMessage(cfg) });
+  }
+
+  try {
+    const result = await uploadToSub2Api(cfg, {
+      refresh_token: refreshToken,
+      email: email || undefined,
+    }, {
+      name: name || email || undefined,
+    });
+    res.json({ ok: true, ...result });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── 批量上传所有 token 到 sub2api ──
 app.post('/api/upload-all-to-sub2api', async (req, res) => {
   const cfg = loadSub2ApiConfig();

--- a/server.js
+++ b/server.js
@@ -21,6 +21,12 @@ if (fs.existsSync(envPath)) {
 }
 
 const { TaskManager } = require('./lib/taskManager');
+const {
+  normalizeSub2ApiConfig,
+  isSub2ApiConfigReady,
+  missingSub2ApiConfigMessage,
+  uploadToSub2Api,
+} = require('./lib/sub2apiService');
 
 const app = express();
 const server = http.createServer(app);
@@ -329,84 +335,14 @@ async function uploadTokenToCpa(cpaConfig, tokenData, filename) {
 
 // ── sub2api 配置 CRUD ──
 app.get('/api/sub2api-config', (req, res) => {
-  const cfg = loadSub2ApiConfig();
-  res.json(cfg || { base_url: '', admin_email: '', admin_password: '', enabled: false });
+  res.json(normalizeSub2ApiConfig(loadSub2ApiConfig()));
 });
 
 app.post('/api/sub2api-config', (req, res) => {
-  const { base_url, admin_email, admin_password, enabled } = req.body;
-  const cfg = {
-    base_url: typeof base_url === 'string' ? base_url.replace(/\/+$/, '') : '',
-    admin_email: typeof admin_email === 'string' ? admin_email : '',
-    admin_password: typeof admin_password === 'string' ? admin_password : '',
-    enabled: !!enabled,
-  };
+  const cfg = normalizeSub2ApiConfig(req.body);
   saveSub2ApiConfig(cfg);
   res.json({ ok: true, config: cfg });
 });
-
-// ── sub2api 上传核心逻辑 ──
-async function uploadToSub2Api(sub2ApiConfig, tokenData) {
-  const http = require('http');
-  const https = require('https');
-  const { URL } = require('url');
-
-  // 1) 登录获取 JWT
-  const loginUrl = new URL('/api/v1/auth/login', sub2ApiConfig.base_url);
-  const loginBody = JSON.stringify({ email: sub2ApiConfig.admin_email, password: sub2ApiConfig.admin_password });
-
-  const doRequest = (url, opts, body) => new Promise((resolve, reject) => {
-    const transport = url.protocol === 'https:' ? https : http;
-    const req = transport.request(url, opts, (resp) => {
-      let data = '';
-      resp.on('data', chunk => data += chunk);
-      resp.on('end', () => resolve({ statusCode: resp.statusCode, body: data }));
-    });
-    req.on('error', reject);
-    if (body) req.write(body);
-    req.end();
-  });
-
-  const loginResult = await doRequest(loginUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(loginBody) },
-  }, loginBody);
-
-  if (loginResult.statusCode !== 200) {
-    throw new Error(`sub2api 登录失败 ${loginResult.statusCode}: ${loginResult.body}`);
-  }
-
-  const loginData = JSON.parse(loginResult.body);
-  const jwt = loginData.data?.access_token;
-  if (!jwt) throw new Error('sub2api 登录返回无 token');
-
-  // 2) 创建账号
-  const accountUrl = new URL('/api/v1/admin/accounts', sub2ApiConfig.base_url);
-  const accountBody = JSON.stringify({
-    platform: 'openai',
-    type: 'oauth',
-    name: tokenData.email || 'extracted',
-    credentials: {
-      refresh_token: tokenData.refresh_token,
-      client_id: 'app_EMoamEEZ73f0CkXaXp7hrann',
-    },
-  });
-
-  const createResult = await doRequest(accountUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${jwt}`,
-      'Content-Length': Buffer.byteLength(accountBody),
-    },
-  }, accountBody);
-
-  if (createResult.statusCode >= 400) {
-    throw new Error(`sub2api 创建账号失败 ${createResult.statusCode}: ${createResult.body}`);
-  }
-
-  return { status: createResult.statusCode, body: createResult.body };
-}
 
 // ── 上传单个 token 到 sub2api ──
 app.post('/api/upload-to-sub2api', async (req, res) => {
@@ -417,8 +353,8 @@ app.post('/api/upload-to-sub2api', async (req, res) => {
   if (!fs.existsSync(filepath)) return res.status(404).json({ error: 'Token 文件不存在' });
 
   const cfg = loadSub2ApiConfig();
-  if (!cfg || !cfg.base_url || !cfg.admin_email || !cfg.admin_password) {
-    return res.status(400).json({ error: '请先配置 sub2api 地址和管理员账号' });
+  if (!isSub2ApiConfigReady(cfg)) {
+    return res.status(400).json({ error: missingSub2ApiConfigMessage(cfg) });
   }
 
   try {
@@ -433,8 +369,8 @@ app.post('/api/upload-to-sub2api', async (req, res) => {
 // ── 批量上传所有 token 到 sub2api ──
 app.post('/api/upload-all-to-sub2api', async (req, res) => {
   const cfg = loadSub2ApiConfig();
-  if (!cfg || !cfg.base_url || !cfg.admin_email || !cfg.admin_password) {
-    return res.status(400).json({ error: '请先配置 sub2api 地址和管理员账号' });
+  if (!isSub2ApiConfigReady(cfg)) {
+    return res.status(400).json({ error: missingSub2ApiConfigMessage(cfg) });
   }
 
   const files = fs.readdirSync(taskManager.outputDir).filter(f => (f.startsWith('codex-') || f.startsWith('token_')) && f.endsWith('.json'));
@@ -443,9 +379,14 @@ app.post('/api/upload-all-to-sub2api', async (req, res) => {
   for (const f of files) {
     try {
       const tokenData = JSON.parse(fs.readFileSync(path.join(taskManager.outputDir, f), 'utf8'));
-      await uploadToSub2Api(cfg, tokenData);
+      const uploadResult = await uploadToSub2Api(cfg, tokenData);
       results.success++;
-      results.details.push({ file: f, status: 'ok' });
+      results.details.push({
+        file: f,
+        status: 'ok',
+        auth_method: uploadResult.auth_method,
+        account: uploadResult.account,
+      });
     } catch (err) {
       results.failed++;
       results.details.push({ file: f, status: 'error', error: err.message });
@@ -457,15 +398,18 @@ app.post('/api/upload-all-to-sub2api', async (req, res) => {
 // ── 提取完成后自动上传 sub2api ──
 async function autoUploadToSub2Api(filename) {
   const cfg = loadSub2ApiConfig();
-  if (!cfg || !cfg.enabled || !cfg.base_url || !cfg.admin_email || !cfg.admin_password) return;
+  if (!cfg || !cfg.enabled || !isSub2ApiConfigReady(cfg)) return;
 
   const filepath = path.join(taskManager.outputDir, filename);
   if (!fs.existsSync(filepath)) return;
 
   try {
     const tokenData = JSON.parse(fs.readFileSync(filepath, 'utf8'));
-    await uploadToSub2Api(cfg, tokenData);
-    broadcastToClients({ type: 'log', source: 'sub2api', message: `[sub2api] ${filename} 自动上传成功` });
+    const uploadResult = await uploadToSub2Api(cfg, tokenData);
+    const account = uploadResult.account || {};
+    const accountInfo = account.id ? `，账号 ID: ${account.id}，状态: ${account.status || 'unknown'}` : '';
+    const authInfo = uploadResult.auth_method === 'admin_api_key' ? 'x-api-key' : '邮箱/密码';
+    broadcastToClients({ type: 'log', source: 'sub2api', message: `[sub2api] ${filename} 自动上传成功（${authInfo}${accountInfo}）` });
   } catch (err) {
     broadcastToClients({ type: 'log', source: 'sub2api', message: `[sub2api] 自动上传失败: ${err.message}` });
   }

--- a/server.js
+++ b/server.js
@@ -383,13 +383,28 @@ app.post('/api/upload-refresh-token-to-sub2api', async (req, res) => {
       refresh_token: refreshToken,
       email: email || undefined,
     }, {
-      name: name || email || undefined,
+      name: name || email || generateManualSub2ApiAccountName(),
     });
     res.json({ ok: true, ...result });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
 });
+
+function generateManualSub2ApiAccountName() {
+  const now = new Date();
+  const pad = (n) => String(n).padStart(2, '0');
+  const timestamp = [
+    now.getUTCFullYear(),
+    pad(now.getUTCMonth() + 1),
+    pad(now.getUTCDate()),
+    '-',
+    pad(now.getUTCHours()),
+    pad(now.getUTCMinutes()),
+    pad(now.getUTCSeconds()),
+  ].join('');
+  return `manual-rt-${timestamp}-${crypto.randomBytes(3).toString('hex')}`;
+}
 
 // ── 批量上传所有 token 到 sub2api ──
 app.post('/api/upload-all-to-sub2api', async (req, res) => {
@@ -447,6 +462,14 @@ wss.on('connection', (ws) => {
 });
 
 const PORT = parseInt(process.env.PORT, 10) || 8090;
-server.listen(PORT, () => {
-  console.log(`GPT Token Extractor running on http://localhost:${PORT}`);
-});
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log(`GPT Token Extractor running on http://localhost:${PORT}`);
+  });
+}
+
+module.exports = {
+  app,
+  server,
+  generateManualSub2ApiAccountName,
+};

--- a/test/sub2apiService.test.js
+++ b/test/sub2apiService.test.js
@@ -125,6 +125,38 @@ test('uploadToSub2Api uses x-api-key and creates account from refresh token', as
   });
 });
 
+test('uploadToSub2Api allows explicit account name for manual refresh token upload', async () => {
+  await withMockSub2Api((record, res) => {
+    assert.equal(record.url, '/api/v1/admin/accounts');
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      data: {
+        id: 321,
+        name: record.json.name,
+        platform: 'openai',
+        type: 'oauth',
+        status: 'active',
+      },
+    }));
+  }, async (baseUrl, requests) => {
+    const result = await uploadToSub2Api({
+      base_url: baseUrl,
+      auth_mode: 'admin_api_key',
+      admin_api_key: 's2a_test_key',
+    }, {
+      email: 'manual@example.com',
+      refresh_token: 'rt_manual',
+    }, {
+      name: 'Manual OpenAI Account',
+    });
+
+    assert.equal(requests[0].json.name, 'Manual OpenAI Account');
+    assert.equal(requests[0].json.credentials.refresh_token, 'rt_manual');
+    assert.equal(result.account.name, 'Manual OpenAI Account');
+    assert.equal(result.account.email, 'manual@example.com');
+  });
+});
+
 test('uploadToSub2Api preserves email/password login flow', async () => {
   await withMockSub2Api((record, res) => {
     if (record.url === '/api/v1/auth/login') {

--- a/test/sub2apiService.test.js
+++ b/test/sub2apiService.test.js
@@ -1,6 +1,8 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const http = require('node:http');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const {
   OPENAI_CODEX_CLIENT_ID,
@@ -9,6 +11,8 @@ const {
   missingSub2ApiConfigMessage,
   uploadToSub2Api,
 } = require('../lib/sub2apiService');
+
+const sub2apiConfigPath = path.join(__dirname, '..', 'config', 'sub2api.json');
 
 async function withMockSub2Api(handler, run) {
   const requests = [];
@@ -214,5 +218,59 @@ test('uploadToSub2Api fails early when token file has no refresh_token', async (
       /缺少 refresh_token/,
     );
     assert.equal(requests.length, 0);
+  });
+});
+
+test('manual refresh-token route generates a unique default account name', async () => {
+  const originalConfig = fs.existsSync(sub2apiConfigPath)
+    ? fs.readFileSync(sub2apiConfigPath, 'utf8')
+    : null;
+
+  await withMockSub2Api((record, res) => {
+    assert.equal(record.url, '/api/v1/admin/accounts');
+    assert.match(record.json.name, /^manual-rt-\d{8}-\d{6}-[0-9a-f]{6}$/);
+    assert.equal(record.json.credentials.refresh_token, 'rt_route');
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      data: {
+        id: 654,
+        name: record.json.name,
+        platform: 'openai',
+        type: 'oauth',
+        status: 'active',
+      },
+    }));
+  }, async (baseUrl) => {
+    try {
+      fs.writeFileSync(sub2apiConfigPath, JSON.stringify({
+        base_url: baseUrl,
+        auth_mode: 'admin_api_key',
+        admin_api_key: 's2a_route',
+        enabled: false,
+      }, null, 2));
+
+      const { server } = require('../server');
+      await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+      const { port } = server.address();
+      try {
+        const response = await fetch(`http://127.0.0.1:${port}/api/upload-refresh-token-to-sub2api`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ refresh_token: 'rt_route' }),
+        });
+        const body = await response.json();
+        assert.equal(response.status, 200);
+        assert.equal(body.ok, true);
+        assert.match(body.account.name, /^manual-rt-\d{8}-\d{6}-[0-9a-f]{6}$/);
+      } finally {
+        await new Promise(resolve => server.close(resolve));
+      }
+    } finally {
+      if (originalConfig === null) {
+        fs.rmSync(sub2apiConfigPath, { force: true });
+      } else {
+        fs.writeFileSync(sub2apiConfigPath, originalConfig);
+      }
+    }
   });
 });

--- a/test/sub2apiService.test.js
+++ b/test/sub2apiService.test.js
@@ -1,0 +1,186 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+
+const {
+  OPENAI_CODEX_CLIENT_ID,
+  normalizeSub2ApiConfig,
+  isSub2ApiConfigReady,
+  missingSub2ApiConfigMessage,
+  uploadToSub2Api,
+} = require('../lib/sub2apiService');
+
+async function withMockSub2Api(handler, run) {
+  const requests = [];
+  const server = http.createServer(async (req, res) => {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      const record = {
+        method: req.method,
+        url: req.url,
+        headers: req.headers,
+        body,
+        json: body ? JSON.parse(body) : null,
+      };
+      requests.push(record);
+      handler(record, res);
+    });
+  });
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  try {
+    return await run(`http://127.0.0.1:${port}`, requests);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+test('normalizeSub2ApiConfig keeps legacy config on email/password mode', () => {
+  const cfg = normalizeSub2ApiConfig({
+    base_url: 'http://sub2api.local///',
+    admin_email: 'admin@example.com',
+    admin_password: 'secret',
+    enabled: true,
+  });
+
+  assert.deepEqual(cfg, {
+    base_url: 'http://sub2api.local',
+    auth_mode: 'email_password',
+    admin_email: 'admin@example.com',
+    admin_password: 'secret',
+    admin_api_key: '',
+    enabled: true,
+  });
+  assert.equal(isSub2ApiConfigReady(cfg), true);
+});
+
+test('isSub2ApiConfigReady validates admin_api_key mode separately', () => {
+  assert.equal(isSub2ApiConfigReady({
+    base_url: 'http://sub2api.local',
+    auth_mode: 'admin_api_key',
+    admin_api_key: '',
+    admin_email: 'admin@example.com',
+    admin_password: 'secret',
+  }), false);
+  assert.equal(missingSub2ApiConfigMessage({
+    base_url: 'http://sub2api.local',
+    auth_mode: 'admin_api_key',
+  }), '请先配置 sub2api Admin API Key');
+  assert.equal(isSub2ApiConfigReady({
+    base_url: 'http://sub2api.local',
+    auth_mode: 'admin_api_key',
+    admin_api_key: 's2a_test',
+  }), true);
+});
+
+test('uploadToSub2Api uses x-api-key and creates account from refresh token', async () => {
+  await withMockSub2Api((record, res) => {
+    assert.equal(record.url, '/api/v1/admin/accounts');
+    assert.equal(record.headers['x-api-key'], 's2a_test_key');
+    assert.equal(record.headers.authorization, undefined);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      data: {
+        id: 123,
+        name: record.json.name,
+        platform: record.json.platform,
+        type: record.json.type,
+        status: 'active',
+        schedulable: true,
+        extra: { email: 'openai@example.com' },
+      },
+    }));
+  }, async (baseUrl, requests) => {
+    const result = await uploadToSub2Api({
+      base_url: baseUrl,
+      auth_mode: 'admin_api_key',
+      admin_api_key: 's2a_test_key',
+    }, {
+      email: 'openai@example.com',
+      refresh_token: 'rt_test',
+    });
+
+    assert.equal(requests.length, 1);
+    assert.deepEqual(requests[0].json, {
+      platform: 'openai',
+      type: 'oauth',
+      name: 'openai@example.com',
+      credentials: {
+        refresh_token: 'rt_test',
+        client_id: OPENAI_CODEX_CLIENT_ID,
+      },
+    });
+    assert.equal(result.auth_method, 'admin_api_key');
+    assert.deepEqual(result.account, {
+      id: 123,
+      name: 'openai@example.com',
+      platform: 'openai',
+      type: 'oauth',
+      status: 'active',
+      schedulable: true,
+      email: 'openai@example.com',
+    });
+  });
+});
+
+test('uploadToSub2Api preserves email/password login flow', async () => {
+  await withMockSub2Api((record, res) => {
+    if (record.url === '/api/v1/auth/login') {
+      assert.equal(record.method, 'POST');
+      assert.deepEqual(record.json, {
+        email: 'admin@example.com',
+        password: 'admin-secret',
+      });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ data: { access_token: 'jwt_test' } }));
+      return;
+    }
+
+    assert.equal(record.url, '/api/v1/admin/accounts');
+    assert.equal(record.headers.authorization, 'Bearer jwt_test');
+    assert.equal(record.headers['x-api-key'], undefined);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      data: {
+        id: 456,
+        name: 'fallback-name',
+        platform: 'openai',
+        type: 'oauth',
+        status: 'active',
+      },
+    }));
+  }, async (baseUrl, requests) => {
+    const result = await uploadToSub2Api({
+      base_url: baseUrl,
+      admin_email: 'admin@example.com',
+      admin_password: 'admin-secret',
+    }, {
+      refresh_token: 'rt_legacy',
+    });
+
+    assert.equal(requests.length, 2);
+    assert.equal(requests[1].json.name, 'extracted');
+    assert.equal(requests[1].json.credentials.refresh_token, 'rt_legacy');
+    assert.equal(result.auth_method, 'email_password');
+    assert.equal(result.account.id, 456);
+    assert.equal(result.account.email, null);
+  });
+});
+
+test('uploadToSub2Api fails early when token file has no refresh_token', async () => {
+  await withMockSub2Api(() => {
+    throw new Error('server should not receive requests');
+  }, async (baseUrl, requests) => {
+    await assert.rejects(
+      uploadToSub2Api({
+        base_url: baseUrl,
+        auth_mode: 'admin_api_key',
+        admin_api_key: 's2a_test_key',
+      }, { email: 'openai@example.com' }),
+      /缺少 refresh_token/,
+    );
+    assert.equal(requests.length, 0);
+  });
+});


### PR DESCRIPTION
**Title**
  Add sub2api Admin API Key upload mode

  **Description**
  This PR adds a new sub2api authentication mode for uploading extracted OpenAI OAuth tokens with an Admin API Key via the x-api-key header.

  The existing admin email/password flow is preserved as the default behavior. Users can now choose either email/password login or Admin API Key in the sub2api upload configuration. When uploading, the tool uses the
  extracted refresh_token to create an OpenAI OAuth account through POST /api/v1/admin/accounts, then displays the created account ID, status, and auth method in the UI/logs.

  **Changes**

  - Added admin_api_key auth mode for sub2api uploads.
  - Preserved the existing email/password JWT flow.
  - Added UI controls for choosing sub2api auth mode.
  - Added upload result details for created sub2api accounts.
  - Extracted sub2api upload logic into a testable service module.
  - Added Node built-in tests for both auth paths and refresh-token validation.

  **Validation**

  npm test
  node --check server.js
  node --check public/app.js
  node --check lib/sub2apiService.js